### PR TITLE
Add --ephemeral parameter to GitHub runner by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Configure github-runner to act as a Github App to obtain a self-hosted runner re
 | GH_ORG          | Github organization name |
 | GROUP  | Runner group defaults to default |
 | LABELS | Labels in addition to default: 'self-hosted,Linux,X64' |
+| EPHEMERAL | Unregister a runner after a job |
 
 ## Tradeoffs
 

--- a/scripts/start
+++ b/scripts/start
@@ -10,6 +10,7 @@ echo "GH_APP_ID: ${GH_INSTALL_ID}"
 
 RUNNER_GROUP=${GROUP:-default}
 RUNNER_LABELS=${LABELS:-}
+EPHEMERAL=${EMPHEMERAL:-"--ephemeral"}
 
 fetch_token() {
   /opt/gha registration-token \
@@ -39,6 +40,7 @@ else
     --work /runner \
     --unattended \
     --replace \
+    ${EPHEMERAL}
     --disableupdate
 fi
 


### PR DESCRIPTION
* Accept an EPHEMERAL environment variable to configure the ephemeral parameter

Rel: https://github.blog/changelog/2021-09-20-github-actions-ephemeral-self-hosted-runners-new-webhooks-for-auto-scaling/