### PR TITLE
Update GitHub Actions Runner from v2.296.1 to v2.296.2

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -6,9 +6,9 @@ RUN cd src && make bin
 FROM docker.io/fedora:36
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG VERSION=2.296.1
+ARG VERSION=2.296.2
 ARG ARCH=x64
-ARG SHA=bc943386c499508c1841bd046f78df4f22582325c5d8d9400de980cb3613ed3b
+ARG SHA=34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -6,9 +6,9 @@ RUN cd src && make bin
 FROM docker.io/fedora:36
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG VERSION=2.296.1
+ARG VERSION=2.296.2
 ARG ARCH=arm64
-ARG SHA=ce11e5d9c1cc299bd8a197b7807f6146fbe7494abb19765fb04664afbdb3755e
+ARG SHA=0297855418398e0efcc487fe3dc581469c38534252f713fba22a603037eaa6b0
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.296.2