### PR TITLE
Update Github Actions Runner from v2.296.2 to v2.297.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -6,9 +6,9 @@ RUN cd src && make bin
 FROM docker.io/fedora:36
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG VERSION=2.296.2
+ARG VERSION=2.297.0
 ARG ARCH=x64
-ARG SHA=34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a
+ARG SHA=eb4e2fa6567d2222686be95ee23210e83fb6356dd0195149f96fd91398323d7f
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -6,9 +6,9 @@ RUN cd src && make bin
 FROM docker.io/fedora:36
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG VERSION=2.296.2
+ARG VERSION=2.297.0
 ARG ARCH=arm64
-ARG SHA=0297855418398e0efcc487fe3dc581469c38534252f713fba22a603037eaa6b0
+ARG SHA=f882e0b88c7afc1effabd64a7b43b12f58060fb349adb5eb87de067c06d1500f
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.297.0