### PR TITLE
Update GitHub Actions Runner from v2.297.0 to v2.298.2

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -6,9 +6,9 @@ RUN cd src && make bin
 FROM docker.io/fedora:36
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG VERSION=2.297.0
+ARG VERSION=2.298.2
 ARG ARCH=x64
-ARG SHA=eb4e2fa6567d2222686be95ee23210e83fb6356dd0195149f96fd91398323d7f
+ARG SHA=0bfd792196ce0ec6f1c65d2a9ad00215b2926ef2c416b8d97615265194477117
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -6,9 +6,9 @@ RUN cd src && make bin
 FROM docker.io/fedora:36
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG VERSION=2.297.0
+ARG VERSION=2.298.2
 ARG ARCH=arm64
-ARG SHA=f882e0b88c7afc1effabd64a7b43b12f58060fb349adb5eb87de067c06d1500f
+ARG SHA=803e4aba36484ef4f126df184220946bc151ae1bbaf2b606b6e2f2280f5042e8
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.298.2