### PR TITLE
Update GitHub Actions Runner from v2.298.2 to v2.299.1

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -6,9 +6,9 @@ RUN cd src && make bin
 FROM docker.io/fedora:36
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG VERSION=2.298.2
+ARG VERSION=2.299.1
 ARG ARCH=x64
-ARG SHA=0bfd792196ce0ec6f1c65d2a9ad00215b2926ef2c416b8d97615265194477117
+ARG SHA=147c14700c6cb997421b9a239c012197f11ea9854cd901ee88ead6fe73a72c74
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -6,9 +6,9 @@ RUN cd src && make bin
 FROM docker.io/fedora:36
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 
-ARG VERSION=2.298.2
+ARG VERSION=2.299.1
 ARG ARCH=arm64
-ARG SHA=803e4aba36484ef4f126df184220946bc151ae1bbaf2b606b6e2f2280f5042e8
+ARG SHA=debe1cc9656963000a4fbdbb004f475ace5b84360ace2f7a191c1ccca6a16c00
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.299.1